### PR TITLE
fix: fix build in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
+default: build
+
 PHONY: build
 build:
+	go build -o buildkite-mcp-server ./cmd/buildkite-mcp-server/main.go
+
+build-snapshot:
 	goreleaser build --snapshot --clean  --single-target
 
 .PHONY: run
 run:
 	go run cmd/buildkite-mcp-server/main.go stdio
+
+test:
+	go test ./... -v


### PR DESCRIPTION
## Description

The current `Makefile` works for CI (`goreleaser` command), but not locally if the `goreleaser` binary is not available, the `build` command should use `go build` with args so that the user can create the binary locally without additional dependencies.

## Changes

- Changes the `build` command to use `go build...`
- Creates a `build-snapshot` command for use with goreleaser
- Adds a default command of `build` so when just `make` is used, the MCP is built
